### PR TITLE
change .pkl to .json

### DIFF
--- a/source/corpushash/hashers.d
+++ b/source/corpushash/hashers.d
@@ -44,8 +44,8 @@ class HashCorpus
     this.encoding = encoding;
     this.hash_function = hash_function;
     this.salt_length = salt_length;
-    this.encode_dictionary_path = buildPath(this.corpus_path, "private/encode_dictionary.pkl");
-    this.decode_dictionary_path = buildPath(this.corpus_path, "private/decode_dictionary.pkl");
+    this.encode_dictionary_path = buildPath(this.corpus_path, "private/encode_dictionary.json");
+    this.decode_dictionary_path = buildPath(this.corpus_path, "private/decode_dictionary.json");
     auto dicts = this._load_dictionaries();
     this.encode_dictionary = dicts[0]; 
     this.decode_dictionary = dicts[1]; 


### PR DESCRIPTION
- I tested and everything worked. the output was a little verbose, is that normal? 

```
Generating test runner configuration 'hashcorpus_d-test-library' for 'library' (library).
Performing "unittest" build using dmd for x86_64.
hashcorpus_d ~master: building configuration "hashcorpus_d-test-library"...
Linking...
Running ./hashcorpus_d-test-library 
setting up output directory on: /home/bruno/Documents/github/corpushashD
std.file.FileException@/usr/include/dmd/phobos/std/file.d(2270): teste/private: File exists
----------------
/usr/include/dmd/phobos/std/file.d:261 @trusted bool std.file.cenforce!(bool).cenforce(bool, const(char)[], const(char)*, immutable(char)[], ulong) [0x5e7a0a]
/usr/include/dmd/phobos/std/file.d:250 @safe void std.file.mkdir!(immutable(char)[]).mkdir(immutable(char)[]) [0x5e5b80]
source/corpushash/hashers.d:159 std.typecons.Tuple!(immutable(dchar)[][immutable(char)[]], immutable(dchar)[][2][immutable(char)[]]).Tuple corpushash.hashers.HashCorpus._load_dictionaries() [0x5d2a2c]
source/corpushash/hashers.d:41 corpushash.hashers.HashCorpus corpushash.hashers.HashCorpus.__ctor(immutable(dchar)[][][], const(immutable(char)[]), const(immutable(char)[]), const(immutable(char)[]), const(uint)) [0x5d1bdc]
source/corpushash/hashers.d:202 void corpushash.hashers.__unittestL199_2() [0x5d2f7f]
??:? void corpushash.hashers.__modtest() [0x6110b4]
??:? scope int core.runtime.runModuleUnitTests().__foreachbody2(scope object.ModuleInfo*) [0x66cab8]
??:? scope int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*)).__lambda2(immutable(object.ModuleInfo*)) [0x62c30a]
??:? scope int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))).__foreachbody2(ref rt.sections_elf_shared.DSO) [0x634a21]
??:? int rt.sections_elf_shared.DSO.opApply(scope int delegate(ref rt.sections_elf_shared.DSO)) [0x634c24]
??:? int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))) [0x6349ad]
??:? int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*)) [0x62c2e1]
??:? runModuleUnitTests [0x66c99c]
??:? scope void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x62fd7e]
??:? scope void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x62fd1b]
??:? _d_run_main [0x62fc8b]
??:? main [0x5d1ac5]
??:? __libc_start_main [0xe16b882f]
4 documents hashed and saved to teste/public.
All unit tests have been run successfully.
```
- I had a little trouble compiling the test because of the pyd extension that wouldn't find the correct python version, there's an issue in the project's github page already

- [ ] I'll try to implement the directories named after timestamps, is that ok?