### PR TITLE
timestamped dir, and change folder creation

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,12 +1,12 @@
 {
-	"name": "hashcorpus_d",
+	"name": "corpushash_d",
 	"authors": [
 		"Flávio C. Coelho"
 	],
 	"dependencies": {
 		"pyd": "~>0.9.9"
 	},
-	"description": "D implementation of python hashcorpus",
+	"description": "D implementation of python corpushash",
 	"copyright": "Copyright © 2017, Flávio C. Coelho",
 	"license": "LGPL3",
     "sourcePaths": [


### PR DESCRIPTION
- implement the timestamped output dir

- remove duplicate creation of private dir in _load_dictionaries

- remove check of corpus_path existence (`if (!this.corpus_path.exists)`) because this does not mean that we don't have to create the public and private dirs